### PR TITLE
Configuration temp fix

### DIFF
--- a/Controls/Update_Pocket/Update_Pocket.cs
+++ b/Controls/Update_Pocket/Update_Pocket.cs
@@ -491,6 +491,8 @@ namespace Pocket_Updater.Controls
         private async void Button_Save_Click(object sender, EventArgs e)
         {
             //string value = Alternate_Location.Text;
+            string Current_Dir = Directory.GetCurrentDirectory();
+            _settings = new SettingsManager(Current_Dir);
             Config config = _settings.GetConfig();
 
             //GitHub Token
@@ -596,13 +598,11 @@ namespace Pocket_Updater.Controls
                     {
                         c.allowPrerelease = true;
                         _settings.UpdateCore(c, core.identifier);
-                        break;
                     }
                     else
                     {
                         c.allowPrerelease = false;
                         _settings.UpdateCore(c, core.identifier);
-                        break;
                     }
                 }
             } 

--- a/Controls/Update_Pocket/Update_Pocket.cs
+++ b/Controls/Update_Pocket/Update_Pocket.cs
@@ -598,11 +598,13 @@ namespace Pocket_Updater.Controls
                     {
                         c.allowPrerelease = true;
                         _settings.UpdateCore(c, core.identifier);
+                        break;
                     }
                     else
                     {
                         c.allowPrerelease = false;
                         _settings.UpdateCore(c, core.identifier);
+                        break;
                     }
                 }
             } 

--- a/lib/Updater/SettingsManager.cs
+++ b/lib/Updater/SettingsManager.cs
@@ -55,6 +55,10 @@ public class SettingsManager
                 _newCores.Add(core);
             }
         }
+        if(_newCores.Count > 0) 
+        {
+            EnableMissingCores(_newCores);
+        }
     }
 
     public List<Core> GetMissingCores() => _newCores;


### PR DESCRIPTION
This is a temporary fix; The core settings get wiped out when saving from the Update Pocket section. I added the new cores to the list; logic was there but didn't seem to be getting used. It saved a lot of headaches and account cuts for a few cases of the issue outlined below.

The issue is that the reference to the Settings Manager under certain cases needs to be referenced correctly. This forces the SettingManager to reload the settings to maintain them. This is only a bandaid until a better fix can be found.